### PR TITLE
Fix reading multibyte character

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
   Exclude:
     - 'bin/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# 1.2.2
+
+* Fix for reading multibyte characters.
+* Added a test for the multibyte character bug.
+* Added tests for silence logger
+* Renamed `Firebug::FirebugError` to `Firebug::Error`.
+
+# 1.2.1
+
+* Fixed nested empty hash bug and added a test for it.
+* Added more documentation.
+
+# 1.2.0
+
+* Rewrote `Firebug::Unserializer` to use `StringIO` instead of `StringScanner`.
+  In most cases this results in a 10x performance increase.
+* Updated `.ruby-version` and `Dockerfile` to use Ruby 2.6
+* Updated development dependencies.

--- a/firebug.gemspec
+++ b/firebug.gemspec
@@ -11,21 +11,21 @@ Gem::Specification.new do |spec| # rubocop:disable BlockLength
   spec.email         = ['aaron@rvshare.com']
 
   spec.summary       = 'Gem for working with CodeIgniter sessions'
-  spec.description   = 'Gem for working with CodeIgniter sessions'
+  spec.description   = spec.summary
   spec.homepage      = 'https://github.com/rvshare/firebug'
   spec.license       = 'MIT'
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.metadata['yard.run'] = 'yri' # use "yard" to build full HTML docs.
+  spec.metadata['yard.run']        = 'yri' # use "yard" to build full HTML docs.
+  spec.metadata['changelog_uri']   = 'https://github.com/rvshare/firebug/blob/master/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = spec.homepage
 
-  spec.add_dependency 'actionpack', '<= 6.0'
-  spec.add_dependency 'activerecord', '<= 6.0'
+  spec.add_dependency 'actionpack', '>= 5.0'
+  spec.add_dependency 'activerecord', '>= 5.0'
   spec.add_dependency 'ruby-mcrypt', '~> 0.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.1'

--- a/lib/action_dispatch/session/code_igniter_store.rb
+++ b/lib/action_dispatch/session/code_igniter_store.rb
@@ -9,6 +9,8 @@ module ActionDispatch # :nodoc:
     class CodeIgniterStore < AbstractStore
       # The key name used to store the session model in the request env.
       SESSION_RECORD_KEY = 'rack.session.record'
+      # The request env hash key that has the logger instance.
+      ACTION_DISPATCH_LOGGER_KEY = 'action_dispatch.logger'
 
       # @param [Object] app
       # @param [Hash] options
@@ -126,6 +128,8 @@ module ActionDispatch # :nodoc:
         Firebug.decrypt_cookie(sid)[:session_id]
       end
 
+      # Attempts to find an existing session record or returns a new one.
+      #
       # @param [ActionDispatch::Request] req
       # @param [String] sid
       # @return [Firebug::Session]
@@ -147,6 +151,8 @@ module ActionDispatch # :nodoc:
         )
       end
 
+      # The parameters used to find a session in the database.
+      #
       # @param [ActionDispatch::Request] req
       # @param [String] sid
       # @return [Hash]
@@ -159,10 +165,12 @@ module ActionDispatch # :nodoc:
         params
       end
 
+      # If silence logger is enabled, disable logger output for the block.
+      #
       # @param [ActionDispatch::Request] req
       def silence_logger(req)
-        logger = req.env['action_dispatch.logger'] || ActiveRecord::Base.logger
-        if logger && Firebug.config.silence_logger
+        logger = req.env[ACTION_DISPATCH_LOGGER_KEY] || ActiveRecord::Base.logger
+        if logger.respond_to?(:silence) && Firebug.config.silence_logger
           logger.silence { yield }
         else
           yield

--- a/lib/firebug/errors.rb
+++ b/lib/firebug/errors.rb
@@ -2,7 +2,7 @@
 
 module Firebug
   # Base error class.
-  FirebugError = Class.new(StandardError)
+  Error = Class.new(StandardError)
   # An error unserializing a string.
-  ParserError = Class.new(FirebugError)
+  ParserError = Class.new(Error)
 end

--- a/lib/firebug/string_io_reader.rb
+++ b/lib/firebug/string_io_reader.rb
@@ -9,7 +9,10 @@ module Firebug
     # @param [Boolean] include If +char+ should be included in the result.
     # @return [String, nil]
     def read_until(char, include: true)
-      if (idx = string.index(char, pos)) # rubocop:disable Style/GuardClause
+      # because UTF-8 is a variable-length encoding and +String#index+ returns the character index, not the byte index,
+      # we use +String#b+ to convert the string to ASCII-8BIT. This forces Ruby to treat each byte as a single
+      # character. This is needed because we have to know how many bytes from +pos+ the +char+ is.
+      if (idx = string.b.index(char, pos)) # rubocop:disable Style/GuardClause
         read(idx - pos + (include ? 1 : 0))
       end
     end

--- a/lib/firebug/version.rb
+++ b/lib/firebug/version.rb
@@ -2,5 +2,5 @@
 
 module Firebug
   # The current version of Firebug
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/spec/firebug/action_dispatch/session/code_igniter_store_spec.rb
+++ b/spec/firebug/action_dispatch/session/code_igniter_store_spec.rb
@@ -297,4 +297,29 @@ RSpec.describe ActionDispatch::Session::CodeIgniterStore do
       expect(store.extract_session_id(request)).to eq(session_id)
     end
   end
+
+  describe '#silence_logger' do
+    let(:logger_out) { StringIO.new }
+    let(:logger) { ActiveSupport::Logger.new(logger_out) }
+    let(:request) { ActionDispatch::TestRequest.create('action_dispatch.logger' => logger) }
+    let(:store) { described_class.new(app) }
+
+    context 'when silence_logger is true' do
+      before { Firebug.config.silence_logger = true }
+
+      it 'outputs nothing to the logger' do
+        store.silence_logger(request) { logger.info('Log message') }
+        expect(logger_out.string).to eq('')
+      end
+    end
+
+    context 'when silence_logger is false' do
+      before { Firebug.config.silence_logger = false }
+
+      it 'outputs messages to the logger' do
+        store.silence_logger(request) { logger.info('Log message') }
+        expect(logger_out.string).to eq("Log message\n")
+      end
+    end
+  end
 end

--- a/spec/firebug/unserializer_spec.rb
+++ b/spec/firebug/unserializer_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Firebug::Unserializer do
     end
   end
 
-  context 'when parsing unicode strings' do
+  context 'when parsing variable-length encoded strings' do
     it 'can parse them correctly' do
-      expect(described_class).to parse('s:3:"√";').as('√')
+      expect(described_class).to parse('a:2:{i:0;s:3:"√";i:1;s:0:"";}').as(['√', ''])
     end
   end
 


### PR DESCRIPTION
* UTF-8 is a variable-length encoding so each character can be 1 to 4
  bytes. `String#index` returns the character index and not the byte
  index. So forcing Ruby to treat the string as a fixed length 8 bit
  encoding we get the proper length in bytes to read.
* Added a test for the bug.
* Added tests for silence logger
* Added changelog.